### PR TITLE
Bump pino version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cazoo-logger",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Codified standards for structured logging",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@types/pino": "^5.8.8",
-    "pino": "^5.12.6",
+    "pino": "^5.17.0",
     "pino-pretty": "^3.2.0",
     "uuid": "^3.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,7 +1605,7 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
-flatstr@^1.0.12, flatstr@^1.0.9:
+flatstr@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
   integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
@@ -3145,20 +3145,20 @@ pino-pretty@^3.2.0:
     readable-stream "^3.4.0"
     split2 "^3.1.1"
 
-pino-std-serializers@^2.3.0:
+pino-std-serializers@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz#cb5e3e58c358b26f88969d7e619ae54bdfcc1ae1"
   integrity sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==
 
-pino@^5.12.6:
-  version "5.13.5"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-5.13.5.tgz#3bfd03c9e7d247adf806960a25c139572ce3cd4f"
-  integrity sha512-NSArDZnjIXgzTLsYA5EhYwLiMe2OmGJ73760Wt5Vj44kUcuPJk4ub29BKtWXGAMwVmW1cQ7Q8jQaLjY/5Gxqcw==
+pino@^5.17.0:
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-5.17.0.tgz#b9def314e82402154f89a25d76a31f20ca84b4c8"
+  integrity sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==
   dependencies:
     fast-redact "^2.0.0"
     fast-safe-stringify "^2.0.7"
-    flatstr "^1.0.9"
-    pino-std-serializers "^2.3.0"
+    flatstr "^1.0.12"
+    pino-std-serializers "^2.4.2"
     quick-format-unescaped "^3.0.3"
     sonic-boom "^0.7.5"
 


### PR DESCRIPTION
In delivery-api, when I update the project dependencies I am getting this error back:

```
node_modules/cazoo-logger/dist/index.d.ts:22:19 - error TS2694: Namespace 'P' has no exported member 'DestinationStream'.
22     stream?: Pino.DestinationStream;
                     ~~~~~~~~~~~~~~~~~
node_modules/cazoo-logger/dist/index.d.ts:25:30 - error TS2694: Namespace 'P' has no exported member 'redactOptions'.
25     redact?: string[] | Pino.redactOptions;
                                ~~~~~~~~~~~~~
Found 2 errors.
``` 

I want to see if the error goes away bumping pino to the latest 5.x version