### PR TITLE
Timeouts are only configured on the root

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -109,9 +109,10 @@ function makeLogger(
 
   const logger = instance as Logger
 
-  const timeout = configureLambdaTimeout(logger, options)
-  logger.timeout = timeout
-
+  if (parent === undefined) {
+    const timeout = configureLambdaTimeout(logger, options)
+    logger.timeout = timeout
+  }
   return logger
 }
 


### PR DESCRIPTION
The logistics timeout bug happens because the logger library is stupid. 

We configure a timeout in the function `makeLogger` which is called for every new logger instance. This results in our reconfiguring the timeout, so that we can't clear it properly at the end of the request.

The fix is stupid: check to see if we're configuring the root logger, but I think this design is played out. I think we need a better design where the _context_ is new for each child, but the machinery is shared.

