### PR TITLE
set callbackWaitsForEmptyEventLoop to false

### DIFF
--- a/test/data/baseContext.ts
+++ b/test/data/baseContext.ts
@@ -7,7 +7,7 @@ export const baseContext: Context = {
   awsRequestId: '',
   logGroupName: '',
   logStreamName: '',
-  callbackWaitsForEmptyEventLoop: true,
+  callbackWaitsForEmptyEventLoop: false,
   succeed: () => {
     /* no-op */
   },


### PR DESCRIPTION
This is more for raising a discussion...

Using the latest version of the cazoo-logger made all our lambdas stay up until timeout.
Also, some of our invocations returned some 5xx, some `failed with 200`.
This is probably due to us not having called done() on the logger - which sorry but is not clear it needs to be used.

I see two options:
- force the usage of the done() method - perhaps on the constructor...?
- stop the lambda if it returns, without waiting for the event loop to clear out